### PR TITLE
added macro for M_PI

### DIFF
--- a/3d-viewing-pinhole-camera/pinhole.cpp
+++ b/3d-viewing-pinhole-camera/pinhole.cpp
@@ -35,7 +35,7 @@
 #include "geometry.h"
 
 #include <fstream>
-
+#define M_PI 3.1415926
 //[comment]
 // List of vertices making up the object
 //[/comment]


### PR DESCRIPTION
This is because not all systems/compilers have this macro ready-to-use.