### PR TITLE
fix compilation error of ray tracing overview code

### DIFF
--- a/ray-tracing-overview/whitted.cpp
+++ b/ray-tracing-overview/whitted.cpp
@@ -37,6 +37,8 @@
 #include <iostream>
 #include <fstream>
 #include <cmath>
+#include <cstring>
+#include <limits>
 
 const float kInfinity = std::numeric_limits<float>::max();
 


### PR DESCRIPTION
Tested with GCC 14.1.1, the following command in the comments won't compile:

```bash
c++ -o whitted whitted.cpp -std=c++11 -O3
```

After adding the two headers, it compiles.